### PR TITLE
Update aldryn-translation-tools to be compatible with Django4.2

### DIFF
--- a/aldryn_translation_tools/__init__.py
+++ b/aldryn_translation_tools/__init__.py
@@ -3,4 +3,4 @@
 from __future__ import unicode_literals
 
 
-__version__ = '0.3.0'
+__version__ = '0.4.1'

--- a/aldryn_translation_tools/admin.py
+++ b/aldryn_translation_tools/admin.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.forms import widgets
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext as _
+from django.utils.encoding import force_str
+from django.utils.translation import gettext as _
 
 from cms.utils.i18n import get_current_language
 from cms.utils.urlutils import admin_reverse
@@ -108,7 +108,7 @@ class AllTranslationsMixin(object):
         langs = []
         for code, lang_name in settings.LANGUAGES:
             classes = ["lang-code", ]
-            title = force_text(lang_name)
+            title = force_str(lang_name)
             if code == current:
                 classes += ["current", ]
             if code in available:

--- a/aldryn_translation_tools/models.py
+++ b/aldryn_translation_tools/models.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import force_str
+from django.utils.translation import gettext_lazy as _
 
 from cms.utils.i18n import get_current_language, get_default_language, get_fallback_languages
 
@@ -68,7 +68,7 @@ class TranslatedAutoSlugifyMixin(object):
         """
         if self.slug_default:
             # Implementing class provides its own, translated string, use it.
-            return force_text(self.slug_default)
+            return force_str(self.slug_default)
 
         object_name = self._meta.verbose_name
 
@@ -82,8 +82,8 @@ class TranslatedAutoSlugifyMixin(object):
             field_name = _('name')
 
         slug_default = _("{0}-without-{1}").format(
-            slugify(force_text(object_name)),
-            slugify(force_text(field_name)),
+            slugify(force_str(object_name)),
+            slugify(force_str(field_name)),
         )
         return slug_default
 
@@ -139,11 +139,11 @@ class TranslatedAutoSlugifyMixin(object):
         """Build the "ideal slug" for this object as a starting point"""
         source = self.get_slug_source()
         if source:
-            source = force_text(source)
-            ideal_slug = force_text(self.slugify(source))
+            source = force_str(source)
+            ideal_slug = force_str(self.slugify(source))
         else:
             # For some reason, the slug came back empty, use the default
-            ideal_slug = force_text(self.get_slug_default())
+            ideal_slug = force_str(self.get_slug_default())
 
         # Trim the length of the ideal slug to the limit allowed the field
         max_length = self.get_slug_max_length()

--- a/test_addon/cms_apps.py
+++ b/test_addon/cms_apps.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from cms.app_base import CMSApp
 from cms.apphook_pool import apphook_pool

--- a/test_addon/models.py
+++ b/test_addon/models.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
-from django.utils.translation import get_language, override, ugettext_lazy as _
+from django.utils.translation import get_language, override, gettext_lazy as _
 
 from parler.models import TranslatableModel, TranslatedFields
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from django.test import TransactionTestCase
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from test_addon.models import Complex, Simple, Unconventional
 


### PR DESCRIPTION
**Key Changes:**

**1. URL Routing Updates**
Deprecated: `url()`
Use: `path()` or `re_path()` from `django.urls`
Before: `from django.conf.urls import url`
After: `from django.urls import re_path`

**2. Translation Utilities**
Deprecated: `ugettext`, `ugettext_lazy`
Use: `gettext`, `gettext_lazy`
Before: `from django.utils.translation import ugettext_lazy as _, ugettext`
After: `from django.utils.translation import gettext_lazy as _, gettext`

**3. Encoding Utilities**
Deprecated: `force_text`
Use: `force_str`
Before: `from django.utils.encoding import force_text`
After: `from django.utils.encoding import force_str`